### PR TITLE
FIX: Disable button search if input is empty

### DIFF
--- a/src/app/components/Search.tsx
+++ b/src/app/components/Search.tsx
@@ -33,8 +33,9 @@ export function Search() {
             </div>
 
             <button 
-                className='bg-[#0175F7] rounded-2xl h-12 w-28 font-mono max-sm:h-10 max-[400px]:h-8 max-[400px]:text-[12px]'
+                className={`bg-[#0175F7] rounded-2xl h-12 w-28 font-mono max-sm:h-10 max-[400px]:h-8 max-[400px]:text-[12px] disabled:opacity-50 disabled:cursor-not-allowed`}
                 onClick={ () => getProfileData() }
+                disabled={ inputSearch.length === 0 }
             >Search</button>
         </div>
     )

--- a/src/app/components/Search.tsx
+++ b/src/app/components/Search.tsx
@@ -33,7 +33,7 @@ export function Search() {
             </div>
 
             <button 
-                className={`bg-[#0175F7] rounded-2xl h-12 w-28 font-mono max-sm:h-10 max-[400px]:h-8 max-[400px]:text-[12px] disabled:opacity-50 disabled:cursor-not-allowed`}
+                className='bg-[#0175F7] rounded-2xl h-12 w-28 font-mono max-sm:h-10 max-[400px]:h-8 max-[400px]:text-[12px] disabled:opacity-50 disabled:cursor-not-allowed'
                 onClick={ () => getProfileData() }
                 disabled={ inputSearch.length === 0 }
             >Search</button>


### PR DESCRIPTION
Created for issue https://github.com/armandocodecr/Devfinder-GithhubCards/issues/5 

Current UI when input is empty:

![image](https://github.com/armandocodecr/Devfinder-GithhubCards/assets/12125288/5caac90a-0a82-4a7f-8182-ffd96efda77e)

Fixed UI when input is empty:

![image](https://github.com/armandocodecr/Devfinder-GithhubCards/assets/12125288/5a200b27-6ef1-49b1-873b-2321a8892e01)
